### PR TITLE
Try to parse TL as UserFn before DB in legacy binary (de)serializer

### DIFF
--- a/backend/libserialize/binary_serialization.ml
+++ b/backend/libserialize/binary_serialization.ml
@@ -96,9 +96,9 @@ type toplevel =
 let toplevel_of_binary_string (str : string) : toplevel =
   try handler_of_binary_string str |> Handler
   with e1 ->
-    ( try db_of_binary_string str |> DB
+    ( try user_fn_of_binary_string str |> UserFn
       with e2 ->
-        ( try user_fn_of_binary_string str |> UserFn
+        ( try db_of_binary_string str |> DB
           with e3 ->
             ( try user_tipe_of_binary_string str |> UserType
               with e4 -> failwith "could not parse binary toplevel" ) ) )


### PR DESCRIPTION
## What is the problem/goal being addressed?
If you
- create a canvas 
- add a user function
- (re)load the canvas with the F# backend,

currently the user function is (seemingly consistently) 'parsed' as a DB TopLevel rather than a UserFn.

## What is the solution to this problem?
In the legacy binary serialization server, attempt to parse UserFns before DBs.

## How are you sure this works/how was this tested?
I've tested this in the UI, and confirmed no regressions in other tests.

As existing integration tests already covered this bug (when the integration tests target F#, which they shortly will by default), I did not write new tests to cover this.
