### PR TITLE
Default Analysis to Blazor

### DIFF
--- a/client/src/appsupport.js
+++ b/client/src/appsupport.js
@@ -323,7 +323,8 @@ window.Dark = {
   analysis: {
     useBlazor: (function () {
       const urlParams = new URLSearchParams(window.location.search);
-      return urlParams.get("use-blazor");
+      const useOcaml = !!urlParams.get("use-ocaml-analysis");
+      return !useOcaml;
     })(),
     requestAnalysis: function (params) {
       if (window.Dark.analysis.useBlazor) {


### PR DESCRIPTION
## What is the problem/goal being addressed?
In-canvas "analysis" is currently powered by the OCaml backend compiled via `js_of_ocaml`.
We'd like to migrate to instead use our F# backend compiled via Blazor.

We attempted a merge of darklang/dark#3485, which resulted in notable production slowness of analysis.
So, that PR was broken down into several others, and this is the "final" PR to address.

## What is the solution to this problem?
Rather than default to the compiled OCaml WASM, with a truthy `use-blazor` query param to use the F# one, default to the Blazor-compiled backend, availing a `use-ocaml-analysis` query param to use the OCaml version
