### PR TITLE
Improve trace-ability of errors in stdlib fns

### DIFF
--- a/backend/src/BackendOnlyStdLib/LibDB.fs
+++ b/backend/src/BackendOnlyStdLib/LibDB.fs
@@ -23,7 +23,8 @@ let fns : List<BuiltInFn> =
       description = "Insert <param val> into <param table>"
       fn =
         function
-        | state, [ v; table ] -> removedFunction state "DB::insert"
+        | state, [ v; table ] ->
+          removedFunction state "DB::insert"
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure

--- a/backend/src/LibBackend/Traces.fs
+++ b/backend/src/LibBackend/Traces.fs
@@ -14,6 +14,7 @@ module PTParser = LibExecution.ProgramTypesParser
 // -------------------------
 // Input variables (including samples)
 // -------------------------
+// TODO_USE_A_SOURCE_ID (check all usages - try to provide a source in some)
 let incomplete = RT.DIncomplete RT.SourceNone
 
 let sampleHttpRequestInputVars : AT.InputVars =

--- a/backend/src/LibExecution/Errors.fs
+++ b/backend/src/LibExecution/Errors.fs
@@ -116,6 +116,7 @@ let incorrectArgsToDError (source : DvalSource) (fn : Fn) (argList : List<Dval>)
 /// When a function has been removed (rarely happens but does happen occasionally)
 let removedFunction (state : ExecutionState) (fnName : string) : DvalTask =
   state.notify state "function removed" [ "fnName", fnName ]
+  // TODO_USE_A_SOURCE_ID It seems reasonable this could take the fn reference ID
   Ply(DError(SourceNone, $"{fnName} was removed from Dark"))
 
 /// When you have a fakeval, you typically just want to return it.

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -584,6 +584,7 @@ and callFn
                   | _ ->
                     Map.find dbname state.program.dbs
                     |> (fun (db : DB.T) -> db.cols)
+                    // TODO_USE_A_SOURCE_ID ?
                     |> List.map (fun (field, _) -> (field, DIncomplete SourceNone))
                     |> Map.ofList
                     |> DObj

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -618,6 +618,7 @@ module Dval =
         | DObj _, _, v when isFake v -> v
         // Error if the key appears twice
         | DObj m, k, v when Map.containsKey k m ->
+          // TODO_USE_A_SOURCE_ID ?
           DError(SourceNone, $"Duplicate key: {k}")
         // Otherwise add it
         | DObj m, k, v -> DObj(Map.add k v m)
@@ -643,6 +644,7 @@ module Dval =
         | DObj _, _, (DErrorRail _ as v) -> v
         // Error if the key appears twice
         | DObj m, k, v when Map.containsKey k m ->
+          // TODO_USE_A_SOURCE_ID ?
           DError(SourceNone, $"Duplicate key: {k}")
         // Otherwise add it
         | DObj m, k, v -> DObj(Map.add k v m)
@@ -670,6 +672,7 @@ module Dval =
     | Some dv -> optionJust dv // checks isFake
     | None -> DOption None
 
+  // TODO_USE_A_SOURCE_ID
   let errStr (s : string) : Dval = DError(SourceNone, s)
 
   let errSStr (source : DvalSource) (s : string) : Dval = DError(source, s)

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -210,7 +210,7 @@ and MatchPattern =
   | MPBlank of id
   | MPTuple of id * MatchPattern * MatchPattern * List<MatchPattern>
 
-type DvalMap = Map<string, Dval>
+type DvalMap = Map<string, id * Dval>
 
 and LambdaImpl = { parameters : List<id * string>; symtable : Symtable; body : Expr }
 
@@ -473,7 +473,7 @@ module Dval =
     | DErrorRail dv -> dv
     | other -> other
 
-  let toPairs (dv : Dval) : Result<List<string * Dval>, string> =
+  let toPairs (dv : Dval) : Result<List<string * id * Dval>, string> =
     match dv with
     | DObj obj -> Ok(Map.toList obj)
     | _ -> Error "expecting str"
@@ -876,7 +876,7 @@ and Fn =
     /// </remarks>
     fn : FnImpl }
 
-and BuiltInFnSig = (ExecutionState * List<Dval>) -> DvalTask
+and BuiltInFnSig = (ExecutionState * List<id * Dval>) -> DvalTask
 
 and FnImpl =
   | StdLib of BuiltInFnSig

--- a/backend/src/LibExecutionStdLib/LibDate.fs
+++ b/backend/src/LibExecutionStdLib/LibDate.fs
@@ -107,7 +107,9 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DStr s ] ->
           match ocamlCompatibleDateParser s with
-          | Error () -> Ply(DError(SourceNone, "Invalid date format"))
+          | Error () ->
+            // TODO_USE_A_SOURCE_ID
+            Ply(DError(SourceNone, "Invalid date format"))
           | Ok d -> Ply(DDate d)
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/backend/src/LibExecutionStdLib/LibDict.fs
+++ b/backend/src/LibExecutionStdLib/LibDict.fs
@@ -336,6 +336,7 @@ let fns : List<BuiltInFn> =
               }
 
             if incomplete.Value then
+              // TODO_USE_A_SOURCE_ID
               return DIncomplete SourceNone (*TODO(ds) source info *)
             else
               let! result = Ply.Map.filterSequentially f o

--- a/backend/src/LibExecutionStdLib/LibFloat.fs
+++ b/backend/src/LibExecutionStdLib/LibFloat.fs
@@ -330,6 +330,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DFloat v; DFloat a; DFloat b ] ->
           if System.Double.IsNaN a || System.Double.IsNaN b then
+            // TODO_USE_A_SOURCE_ID
             Ply(DError(SourceNone, "clamp requires arguments to be valid numbers"))
           else
             let min, max = if a < b then (a, b) else (b, a)

--- a/backend/src/LibExecutionStdLib/LibJson.fs
+++ b/backend/src/LibExecutionStdLib/LibJson.fs
@@ -59,7 +59,9 @@ let fns : List<BuiltInFn> =
         | _, [ DStr json ] ->
           match DvalReprLegacyExternal.ofUnknownJsonV1 json with
           | Ok dv -> Ply dv
-          | Error msg -> Ply(DError(SourceNone, msg))
+          | Error msg ->
+            // TODO_USE_A_SOURCE_ID
+            Ply(DError(SourceNone, msg))
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure

--- a/backend/src/LibExecutionStdLib/LibList.fs
+++ b/backend/src/LibExecutionStdLib/LibList.fs
@@ -758,6 +758,7 @@ let fns : List<BuiltInFn> =
               }
 
             if incomplete.Value then
+              // TODO_USE_A_SOURCE_ID
               return DIncomplete SourceNone
             else
               let! result = Ply.List.filterSequentially f l
@@ -808,6 +809,7 @@ let fns : List<BuiltInFn> =
               }
 
             if incomplete then
+              // TODO_USE_A_SOURCE_ID
               return DIncomplete SourceNone
             else
               let! result = Ply.List.filterSequentially f l


### PR DESCRIPTION
Changelog:

```
Editor
- improve trace-ability of errors that occur in stdlib fns
```

Increase our accuracy, frequency, and precision in which we 'blame' errors, by replacing `SourceNone` usages with the IDs of code that caused the errors originally.

keeping this PR in my fork until it's useful

it'd also be worth reviewing the DErrors that _do_ have ids - consider whether the ID assigned as the issue is truly the best ID.